### PR TITLE
add HCP Terraform run tasks

### DIFF
--- a/hashicorp/hcp_terraform/run_tasks/README.md
+++ b/hashicorp/hcp_terraform/run_tasks/README.md
@@ -1,0 +1,13 @@
+## Runtask Terraform Plan Analyzer
+
+Integrate Amazon Bedrock to your HashiCorp Cloud Platform Terraform (Terraform Cloud) Run Tasks for:
+
+* Analyzing Terraform plan and generate short-summary
+* Function calling for other API-based analysis (e.g AMI analysis)
+
+How to use it:
+
+1. First run the [setup](./setup/) module to deploy the pre-requisite infrastructure
+2. Then run the [example](./example/) module that will demonstrate the Terraform plan analysis using Amazon Bedrock
+
+Check the complete Terraform module in the [Terraform registry](https://registry.terraform.io/modules/aws-ia/runtask-tf-plan-analyzer/aws/latest)

--- a/hashicorp/hcp_terraform/run_tasks/example/main.tf
+++ b/hashicorp/hcp_terraform/run_tasks/example/main.tf
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################################
+# Locals
+################################################################################
+
+locals {
+  name   = "cloud-infra-ai-example"
+  region = "us-east-1"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  tags = {
+    environment  = "development"
+  }
+}
+
+################################################################################
+# Networking
+################################################################################
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+  azs             = local.azs
+
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+  
+  manage_default_network_acl    = true
+  default_network_acl_tags      = { Name = "${local.name}-default" }
+  manage_default_route_table    = true
+  default_route_table_tags      = { Name = "${local.name}-default" }
+  manage_default_security_group = true
+  default_security_group_tags   = { Name = "${local.name}-default" }#
+  tags = local.tags
+}
+
+resource "aws_network_interface" "primary" {
+  subnet_id   = module.vpc.private_subnets[0]
+}
+
+data "aws_ssm_parameter" "ecs_optimized_ami_linux_2" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/amzn2-ami-ecs-hvm-2.0.20240604-x86_64-ebs"
+}
+
+data "aws_ssm_parameter" "ecs_optimized_ami_linux_2023" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/al2023-ami-ecs-hvm-2023.0.20240610-kernel-6.1-x86_64"
+}
+resource "aws_instance" "ecs" {
+  ami           = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_linux_2.value)["image_id"]
+  instance_type = "t3.micro"
+
+    network_interface {
+        network_interface_id = aws_network_interface.primary.id
+        device_index         = 0
+    }
+    tags = {
+        Name = local.name
+    }
+}

--- a/hashicorp/hcp_terraform/run_tasks/example/providers.tf
+++ b/hashicorp/hcp_terraform/run_tasks/example/providers.tf
@@ -1,0 +1,21 @@
+terraform {
+  cloud {
+    # TODO: Change this to your Terraform Cloud org name.
+    organization = "ENTER_YOUR_TERRAFORM_CLOUD_REGION"
+    workspaces {
+      name = "my-aws-workspace"
+    }
+  }
+
+  required_version = ">= 1.0.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.56.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/hashicorp/hcp_terraform/run_tasks/example/variables.tf
+++ b/hashicorp/hcp_terraform/run_tasks/example/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  description = "AWS region to deploy the resources"
+  default     = "us-west-2"
+}

--- a/hashicorp/hcp_terraform/run_tasks/setup/main.tf
+++ b/hashicorp/hcp_terraform/run_tasks/setup/main.tf
@@ -1,0 +1,29 @@
+#####################################################################################
+# Terraform module examples are meant to show an _example_ on how to use a module
+# per use-case. The code below should not be copied directly but referenced in order
+# to build your own root module that invokes this module
+#####################################################################################
+
+data "aws_region" "current" {}
+
+data "tfe_organization" "hcp_tf_org" {
+  name = var.hcp_tf_org
+}
+
+module "hcp_tf_run_task" {
+  source             = "aws-ia/runtask-tf-plan-analyzer/aws"
+  version            = "0.0.2"
+  aws_region         = data.aws_region.current.name
+  hcp_tf_org         = data.tfe_organization.hcp_tf_org.name
+  run_task_iam_roles = var.tf_run_task_logic_iam_roles
+  deploy_waf         = true
+}
+
+resource "tfe_organization_run_task" "bedrock_plan_analyzer" {
+  enabled      = true
+  organization = data.tfe_organization.hcp_tf_org.name
+  url          = module.hcp_tf_run_task.runtask_url
+  hmac_key     = module.hcp_tf_run_task.runtask_hmac
+  name         = "Bedrock-TF-Plan-Analyzer"
+  description  = "Analyze TF plan using Amazon Bedrock"
+}

--- a/hashicorp/hcp_terraform/run_tasks/setup/oidc.tf
+++ b/hashicorp/hcp_terraform/run_tasks/setup/oidc.tf
@@ -1,0 +1,79 @@
+# Data source used to grab the TLS certificate for Terraform Cloud.
+#
+# https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate
+data "tls_certificate" "tfc_certificate" {
+  url = "https://${var.tfc_hostname}"
+}
+
+# Creates an OIDC provider which is restricted to
+#
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider
+resource "aws_iam_openid_connect_provider" "tfc_provider" {
+  url             = data.tls_certificate.tfc_certificate.url
+  client_id_list  = [var.tfc_aws_audience]
+  thumbprint_list = [data.tls_certificate.tfc_certificate.certificates[0].sha1_fingerprint]
+}
+
+# Creates a role which can only be used by the specified Terraform
+# cloud workspace.
+#
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role
+resource "aws_iam_role" "tfc_role" {
+  name = "tfc-role"
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Effect": "Allow",
+     "Principal": {
+       "Federated": "${aws_iam_openid_connect_provider.tfc_provider.arn}"
+     },
+     "Action": "sts:AssumeRoleWithWebIdentity",
+     "Condition": {
+       "StringEquals": {
+         "${var.tfc_hostname}:aud": "${one(aws_iam_openid_connect_provider.tfc_provider.client_id_list)}"
+       },
+       "StringLike": {
+         "${var.tfc_hostname}:sub": "organization:${var.hcp_tf_org}:project:${var.tfc_project_name}:workspace:${var.tfc_workspace_name}:run_phase:*"
+       }
+     }
+   }
+ ]
+}
+EOF
+}
+
+# Creates a policy that will be used to define the permissions that
+# the previously created role has within AWS.
+#
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy
+resource "aws_iam_policy" "tfc_policy" {
+  name        = "tfc-policy"
+  description = "TFC run policy"
+
+  policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Effect": "Allow",
+     "Action": [
+       "*"
+     ],
+     "Resource": "*"
+   }
+ ]
+}
+EOF
+}
+
+# Creates an attachment to associate the above policy with the
+# previously created role.
+#
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment
+resource "aws_iam_role_policy_attachment" "tfc_policy_attachment" {
+  role       = aws_iam_role.tfc_role.name
+  policy_arn = aws_iam_policy.tfc_policy.arn
+}

--- a/hashicorp/hcp_terraform/run_tasks/setup/outputs.tf
+++ b/hashicorp/hcp_terraform/run_tasks/setup/outputs.tf
@@ -1,0 +1,11 @@
+output "runtask_url" {
+  value = module.hcp_tf_run_task.runtask_url
+}
+
+output "runtask_name" {
+  value = tfe_organization_run_task.bedrock_plan_analyzer.name
+}
+
+output "workspace_name" {
+  value = tfe_workspace.my_workspace.name
+}

--- a/hashicorp/hcp_terraform/run_tasks/setup/providers.tf
+++ b/hashicorp/hcp_terraform/run_tasks/setup/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.0.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.56.1"
+    }
+
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~>0.38.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  alias  = "cloudfront_waf"
+  region = "us-east-1" # for Cloudfront WAF only, must be in us-east-1
+}
+
+provider "tfe" {
+}

--- a/hashicorp/hcp_terraform/run_tasks/setup/terraform.auto.tfvars
+++ b/hashicorp/hcp_terraform/run_tasks/setup/terraform.auto.tfvars
@@ -1,0 +1,2 @@
+hcp_tf_org="ENTER_YOUR_TERRAFORM_CLOUD_REGION"
+region="us-west-2"

--- a/hashicorp/hcp_terraform/run_tasks/setup/tfe.tf
+++ b/hashicorp/hcp_terraform/run_tasks/setup/tfe.tf
@@ -1,0 +1,44 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name         = var.tfc_project_name
+  organization = var.hcp_tf_org
+}
+
+# Runs in this workspace will be automatically authenticated
+# to AWS with the permissions set in the AWS policy.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace
+resource "tfe_workspace" "my_workspace" {
+  name         = var.tfc_workspace_name
+  organization = var.hcp_tf_org
+  project_id   = data.tfe_project.tfc_project.id
+}
+
+# The following variables must be set to allow runs
+# to authenticate to AWS.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable
+resource "tfe_variable" "enable_aws_provider_auth" {
+  workspace_id = tfe_workspace.my_workspace.id
+
+  key      = "TFC_AWS_PROVIDER_AUTH"
+  value    = "true"
+  category = "env"
+
+  description = "Enable the Workload Identity integration for AWS."
+}
+
+resource "tfe_variable" "tfc_aws_role_arn" {
+  workspace_id = tfe_workspace.my_workspace.id
+
+  key      = "TFC_AWS_RUN_ROLE_ARN"
+  value    = aws_iam_role.tfc_role.arn
+  category = "env"
+
+  description = "The AWS role arn runs will use to authenticate."
+}

--- a/hashicorp/hcp_terraform/run_tasks/setup/variables.tf
+++ b/hashicorp/hcp_terraform/run_tasks/setup/variables.tf
@@ -1,0 +1,46 @@
+variable "hcp_tf_org" {
+  type        = string
+  description = "HCP Terraform Organization name"
+}
+
+variable "tf_run_task_logic_iam_roles" {
+  type        = list(string)
+  description = "values for the IAM roles to be used by the run task logic"
+  default     = []
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy the resources"
+  default     = "us-east-1"
+}
+
+variable "tf_run_task_image_tag" {
+  type        = string
+  description = "value for the docker image tag to be used by the run task logic"
+  default     = "latest"
+}
+
+variable "tfc_aws_audience" {
+  type        = string
+  default     = "aws.workload.identity"
+  description = "The audience value to use in run identity tokens"
+}
+
+variable "tfc_hostname" {
+  type        = string
+  default     = "app.terraform.io"
+  description = "The hostname of the TFC or TFE instance you'd like to use with AWS"
+}
+
+variable "tfc_project_name" {
+  type        = string
+  default     = "Default Project"
+  description = "The project under which a workspace will be created"
+}
+
+variable "tfc_workspace_name" {
+  type        = string
+  default     = "my-aws-workspace"
+  description = "The name of the workspace that you'd like to create and connect to AWS"
+}


### PR DESCRIPTION
*Description of changes:*

This pull request add example on how to use HashiCorp Terraform Cloud Runtask to analyze Terraform plan output using Bedrock.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
