### PR TITLE
Set AWS Region in Bedrock calls to support region-dependent models

### DIFF
--- a/elastic/mcp/official-elastic-mcp-server-demo/mcp-clients/multi_server_mcp_client_travel_reservations.py
+++ b/elastic/mcp/official-elastic-mcp-server-demo/mcp-clients/multi_server_mcp_client_travel_reservations.py
@@ -572,7 +572,8 @@ class MultiServerMCPClient:
     def __init__(self):
         self.sessions: Dict[str, ClientSession] = {}
         self.exit_stack = AsyncExitStack()
-        self.bedrock = boto3.client(service_name='bedrock-runtime', region_name='us-west-2')
+        self.aws_region = os.getenv("AWS_REGION", "us-west-2")
+        self.bedrock = boto3.client(service_name='bedrock-runtime', region_name=self.aws_region)
         self.all_tools = {}
         self.server_configs = {}
         


### PR DESCRIPTION
*Description of changes:*
Sets explicit AWS region configuration in Bedrock client calls to ensure compatibility with region-dependent models and avoid region-related errors. Not all models are available in all regions, and it is best to not hardcode us-west-2.

## Changes Made
- Removed hardcoded us-west-2 region dependency
- Allows users to configure region based on model availability in their account via env

## Type of Change
- [ ] Bug fix
- [x] Enhancement  
- [ ] Breaking change
- [ ] Documentation update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
