### PR TITLE
feat(datadog): add travel concierge agent core code with OTEL observability

### DIFF
--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/Dockerfile
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/Dockerfile
@@ -1,0 +1,50 @@
+FROM python:3.13-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Make entrypoint executable
+RUN chmod +x entrypoint.sh
+
+# Set environment variables
+ENV PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Create non-root user
+RUN useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /app
+USER appuser
+
+# Expose port for MCP server
+EXPOSE 8000
+
+# Datadog LLM Observability via pure OTEL (no ddtrace agent required)
+# dd_init.py configures TracerProvider to export traces to Datadog
+ENV DD_SITE=datadoghq.com
+ENV OTEL_SERVICE_NAME=itinerary-mcp-server
+
+# Disable AgentCore's built-in ADOT — using Datadog OTEL instead
+ENV DISABLE_ADOT_OBSERVABILITY=true
+
+# Required for GenAI semantic conventions (v1.37+)
+ENV OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+# Run the MCP server — entrypoint resolves DD_API_KEY, dd_init.py configures OTEL
+CMD ["bash", "entrypoint.sh"]

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/__init__.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/__init__.py
@@ -1,0 +1,6 @@
+"""
+Itinerary Tools Module
+
+This module contains the itinerary management tools for handling
+travel itinerary operations.
+"""

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/dd_init.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/dd_init.py
@@ -1,0 +1,78 @@
+"""
+Datadog LLM Observability initialization for MCP Itinerary Tools server via OpenTelemetry.
+
+AgentCore integration approach (per PR #1097):
+- DISABLE_ADOT_OBSERVABILITY=true disables AgentCore's built-in ADOT/CloudWatch pipeline
+- OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental enables GenAI semantic conventions
+- A custom TracerProvider with OTLPSpanExporter sends traces directly to Datadog
+- dd-otlp-source=llmobs routes traces to Datadog LLM Observability views
+- DD_API_KEY is resolved from Secrets Manager at startup (via entrypoint.sh and here as backup)
+
+No ddtrace or Datadog Agent required — pure OTEL export to Datadog.
+
+Must be imported FIRST in every Python entry point (before any other imports).
+"""
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Disable AgentCore's built-in ADOT so we can set our own TracerProvider
+os.environ.setdefault("DISABLE_ADOT_OBSERVABILITY", "true")
+
+# Required for GenAI semantic conventions (v1.37+)
+os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
+
+
+def _resolve_dd_api_key():
+    """Resolve DD_API_KEY from Secrets Manager if not already set."""
+    secret_arn = os.environ.get("DD_API_KEY_SECRET_ARN")
+    if not secret_arn or os.environ.get("DD_API_KEY"):
+        return
+    try:
+        import boto3
+        client = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+        resp = client.get_secret_value(SecretId=secret_arn)
+        os.environ["DD_API_KEY"] = resp["SecretString"]
+        logger.info("DD_API_KEY resolved from Secrets Manager")
+    except Exception as e:
+        logger.error("Failed to resolve DD_API_KEY: %s", e)
+
+
+def _configure_datadog_otel():
+    """Configure OpenTelemetry TracerProvider to export traces to Datadog LLM Observability."""
+    dd_api_key = os.environ.get("DD_API_KEY", "")
+    dd_site = os.environ.get("DD_SITE", "datadoghq.com")
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "itinerary-mcp-server")
+
+    if not dd_api_key:
+        logger.warning("DD_API_KEY not set. Traces will not be sent to Datadog.")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({"service.name": service_name})
+        exporter = OTLPSpanExporter(
+            endpoint=f"https://trace.agent.{dd_site}/v1/traces",
+            headers={"dd-api-key": dd_api_key, "dd-otlp-source": "llmobs"},
+        )
+        provider = TracerProvider(resource=resource)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+
+        # Ensure spans are flushed on shutdown
+        import atexit
+        atexit.register(provider.shutdown)
+
+        logger.info("Datadog LLM Observability configured (service: %s)", service_name)
+    except Exception as e:
+        logger.error("Failed to configure Datadog OTEL: %s", e)
+
+
+_resolve_dd_api_key()
+_configure_datadog_otel()

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/dynamodb_manager.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/dynamodb_manager.py
@@ -1,0 +1,130 @@
+import os
+import uuid
+import boto3
+from datetime import datetime, timezone
+from botocore.exceptions import ClientError
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class DynamoDBManager:
+    """DynamoDB client for itinerary operations."""
+
+    def __init__(self, region_name: str = None):
+        self.region_name = region_name or os.environ.get("AWS_REGION")
+
+        # Initialize DynamoDB resource
+        self.dynamodb = boto3.resource("dynamodb", region_name=self.region_name)
+
+        # Table names from environment variables
+        self.user_profile_table_name = os.environ.get("USER_PROFILE_TABLE_NAME")
+        self.itinerary_table_name = os.environ.get("ITINERARY_TABLE_NAME")
+
+        # Get table references
+        self.user_profile_table = self.dynamodb.Table(self.user_profile_table_name)
+        self.itinerary_table = self.dynamodb.Table(self.itinerary_table_name)
+
+        logger.info(f"DynamoDB Manager initialized with region: {self.region_name}")
+        logger.info(f"Itinerary table: {self.itinerary_table_name}")
+
+    def get_itinerary_items(self, user_id: str):
+        """Get all itinerary items for a user using GSI."""
+        try:
+            response = self.itinerary_table.query(
+                IndexName="itinerariesByUser_id",
+                KeyConditionExpression="user_id = :user_id",
+                ExpressionAttributeValues={":user_id": user_id},
+            )
+
+            items = response.get("Items", [])
+            logger.info(f"Retrieved {len(items)} itinerary items for user {user_id}")
+            return items
+
+        except ClientError as e:
+            logger.error(f"Error getting itinerary items: {e}")
+            raise
+
+    def add_itinerary_item(self, user_id: str, item: dict):
+        """Add an item to the itinerary."""
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+
+            itinerary_item = {
+                "id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "type": item.get("item_type", item.get("type", "activity")),
+                "title": item.get("title", ""),
+                "date": item.get("date", ""),
+                "time_of_day": item.get("time_of_day", ""),
+                "details": item.get("details", ""),
+                "location": item.get("location", ""),
+                "price": item.get("price", ""),
+                "createdAt": now,
+                "updatedAt": now,
+            }
+
+            self.itinerary_table.put_item(Item=itinerary_item)
+            logger.info(
+                f"Added itinerary item '{item.get('title')}' for user {user_id}"
+            )
+            return itinerary_item
+
+        except ClientError as e:
+            logger.error(f"Error adding itinerary item: {e}")
+            raise
+
+    def remove_itinerary_item(self, user_id: str, item_id: str):
+        """Remove an item from the itinerary."""
+        try:
+            self.itinerary_table.delete_item(Key={"id": item_id})
+            logger.info(f"Removed itinerary item {item_id} for user {user_id}")
+
+        except ClientError as e:
+            logger.error(f"Error removing itinerary item: {e}")
+            raise
+
+    def update_itinerary_item(self, user_id: str, item_id: str, updates: dict):
+        """Update an itinerary item."""
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+
+            # Build update expression
+            update_parts = []
+            expr_values = {":updatedAt": now}
+            expr_names = {}
+
+            for key, value in updates.items():
+                safe_key = f"#{key}"
+                expr_names[safe_key] = key
+                expr_values[f":{key}"] = value
+                update_parts.append(f"{safe_key} = :{key}")
+
+            update_parts.append("updatedAt = :updatedAt")
+            update_expression = "SET " + ", ".join(update_parts)
+
+            self.itinerary_table.update_item(
+                Key={"id": item_id},
+                UpdateExpression=update_expression,
+                ExpressionAttributeValues=expr_values,
+                ExpressionAttributeNames=expr_names if expr_names else None,
+            )
+            logger.info(f"Updated itinerary item {item_id} for user {user_id}")
+
+        except ClientError as e:
+            logger.error(f"Error updating itinerary item: {e}")
+            raise
+
+    def get_user_profile(self, user_id: str):
+        """Get user profile from the UserProfile table."""
+        try:
+            response = self.user_profile_table.get_item(Key={"id": user_id})
+
+            if "Item" in response:
+                return response["Item"]
+            return None
+
+        except ClientError as e:
+            logger.error(f"Error getting user profile: {e}")
+            raise

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/entrypoint.sh
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Entrypoint for MCP itinerary tools — Datadog LLM Observability via pure OTEL.
+#
+# How it works:
+# 1. DD_API_KEY is resolved from Secrets Manager
+# 2. dd_init.py (imported first in server.py) configures an OTEL TracerProvider
+#    that exports traces directly to Datadog's OTLP endpoint
+# 3. DISABLE_ADOT_OBSERVABILITY=true prevents AgentCore's ADOT from conflicting
+#
+# No ddtrace or Datadog Agent required.
+
+if [ -n "$DD_API_KEY_SECRET_ARN" ] && [ -z "$DD_API_KEY" ]; then
+    echo "Resolving DD_API_KEY from Secrets Manager..."
+    export DD_API_KEY=$(python -c "
+import boto3, os
+client = boto3.client('secretsmanager', region_name=os.environ.get('AWS_REGION', 'us-east-1'))
+print(client.get_secret_value(SecretId=os.environ['DD_API_KEY_SECRET_ARN'])['SecretString'])
+" 2>/dev/null)
+    if [ -n "$DD_API_KEY" ]; then
+        echo "DD_API_KEY resolved successfully"
+    else
+        echo "WARNING: Failed to resolve DD_API_KEY from Secrets Manager"
+    fi
+fi
+
+exec python server.py

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/requirements.txt
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/requirements.txt
@@ -1,0 +1,7 @@
+# MCP Itinerary Tools Dependencies
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp-proto-http>=1.20.0
+mcp>=1.23.3
+boto3>=1.40.8
+pydantic>=2.6.0
+anyio>=4.6.0

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/server.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_itinerary_tools/server.py
@@ -1,0 +1,206 @@
+"""
+Itinerary Tools MCP Server
+
+Exposes itinerary management tools via MCP protocol.
+No agent logic - just pure tool implementations.
+"""
+
+import dd_init  # noqa: F401 - must be first import to configure OTEL TracerProvider
+import os
+import logging
+from typing import List, Dict, Any
+from mcp.server import FastMCP
+from dynamodb_manager import DynamoDBManager
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+REGION = os.getenv("AWS_REGION")
+if not REGION:
+    raise ValueError("AWS_REGION environment variable is required")
+
+# Create MCP server
+mcp = FastMCP(
+    "Itinerary Tools", host="0.0.0.0", stateless_http=True
+)  # nosec B104:standard pattern for containerized MCP serverss
+
+# Initialize DynamoDB manager
+dynamodb_manager = None
+
+
+def get_dynamodb_manager():
+    """Get or create DynamoDB manager instance."""
+    global dynamodb_manager
+    if dynamodb_manager is None:
+        dynamodb_manager = DynamoDBManager(region_name=REGION)
+    return dynamodb_manager
+
+
+# =============================================================================
+# MCP TOOLS - Raw tool exposure
+# =============================================================================
+
+
+@mcp.tool()
+def itinerary_get(user_id: str) -> List[Dict[str, Any]]:
+    """
+    Get the user's saved itinerary.
+
+    Args:
+        user_id: User identifier
+
+    Returns:
+        List of itinerary items (flights, hotels, activities)
+    """
+    try:
+        manager = get_dynamodb_manager()
+        items = manager.get_itinerary_items(user_id)
+        return items
+    except Exception as e:
+        logger.error(f"Error getting itinerary: {e}")
+        return []
+
+
+@mcp.tool()
+def itinerary_save(
+    user_id: str,
+    item_type: str,
+    title: str,
+    date: str,
+    details: str = "",
+    location: str = "",
+    price: str = "",
+    time_of_day: str = "",
+) -> Dict[str, Any]:
+    """
+    Save an item to the user's itinerary.
+
+    Args:
+        user_id: User identifier
+        item_type: Type of item ('flight', 'hotel', 'activity', 'restaurant')
+        title: Item title/name
+        date: Date in YYYY-MM-DD format
+        details: Additional details
+        location: Location/address
+        price: Price if applicable
+        time_of_day: Time of day ('morning', 'afternoon', 'evening')
+
+    Returns:
+        Success status and message
+    """
+    try:
+        manager = get_dynamodb_manager()
+
+        itinerary_item = {
+            "item_type": item_type,
+            "title": title,
+            "date": date,
+            "details": details,
+            "location": location,
+            "price": price,
+            "time_of_day": time_of_day,
+        }
+
+        manager.add_itinerary_item(user_id, itinerary_item)
+
+        return {"success": True, "message": f"Added {title} to itinerary for {date}"}
+    except Exception as e:
+        logger.error(f"Error saving itinerary item: {e}")
+        return {"success": False, "message": str(e)}
+
+
+@mcp.tool()
+def itinerary_remove(user_id: str, item_id: str) -> Dict[str, Any]:
+    """
+    Remove an item from the itinerary.
+
+    Args:
+        user_id: User identifier
+        item_id: ID of the item to remove
+
+    Returns:
+        Success status and message
+    """
+    try:
+        manager = get_dynamodb_manager()
+        manager.remove_itinerary_item(user_id, item_id)
+
+        return {"success": True, "message": "Item removed from itinerary"}
+    except Exception as e:
+        logger.error(f"Error removing itinerary item: {e}")
+        return {"success": False, "message": str(e)}
+
+
+@mcp.tool()
+def itinerary_clear(user_id: str) -> Dict[str, Any]:
+    """
+    Clear all items from the user's itinerary.
+
+    Args:
+        user_id: User identifier
+
+    Returns:
+        Success status and count of removed items
+    """
+    try:
+        manager = get_dynamodb_manager()
+        items = manager.get_itinerary_items(user_id)
+
+        if not items:
+            return {
+                "success": True,
+                "items_removed": 0,
+                "message": "Itinerary is already empty.",
+            }
+
+        for item in items:
+            manager.remove_itinerary_item(user_id, item.get("id"))
+
+        return {
+            "success": True,
+            "items_removed": len(items),
+            "message": f"Removed {len(items)} items from itinerary.",
+        }
+    except Exception as e:
+        logger.error(f"Error clearing itinerary: {e}")
+        return {"success": False, "message": str(e)}
+
+
+@mcp.tool()
+def itinerary_update_date(user_id: str, item_id: str, new_date: str) -> Dict[str, Any]:
+    """
+    Update the date for an itinerary item.
+
+    Args:
+        user_id: User identifier
+        item_id: ID of the item to update
+        new_date: New date in YYYY-MM-DD format
+
+    Returns:
+        Success status and message
+    """
+    try:
+        from datetime import datetime
+
+        try:
+            datetime.strptime(new_date, "%Y-%m-%d")
+        except ValueError:
+            return {"success": False, "message": "Date must be in YYYY-MM-DD format"}
+
+        manager = get_dynamodb_manager()
+        manager.update_itinerary_item(user_id, item_id, {"date": new_date})
+
+        return {"success": True, "message": f"Updated date to {new_date}"}
+    except Exception as e:
+        logger.error(f"Error updating date: {e}")
+        return {"success": False, "message": str(e)}
+
+
+# =============================================================================
+# SERVER STARTUP
+# =============================================================================
+
+if __name__ == "__main__":
+    logger.info("Starting Itinerary Tools MCP Server...")
+    mcp.run(transport="streamable-http")

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/Dockerfile
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/Dockerfile
@@ -1,0 +1,49 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install system dependencies (curl needed for health check)
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Make entrypoint executable
+RUN chmod +x entrypoint.sh
+
+# Set environment variables
+ENV PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Create non-root user
+RUN useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /app
+USER appuser
+
+# Expose port for MCP server
+EXPOSE 8000
+
+# Datadog LLM Observability via pure OTEL (no ddtrace agent required)
+# dd_init.py configures TracerProvider to export traces to Datadog
+ENV DD_SITE=datadoghq.com
+ENV OTEL_SERVICE_NAME=travel-mcp-server
+
+# Disable AgentCore's built-in ADOT — using Datadog OTEL instead
+ENV DISABLE_ADOT_OBSERVABILITY=true
+
+# Required for GenAI semantic conventions (v1.37+)
+ENV OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+
+# Add HEALTHCHECK 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl --fail http://localhost:8000/health || exit 1
+
+# Run the MCP server — entrypoint resolves DD_API_KEY, dd_init.py configures OTEL
+CMD ["bash", "entrypoint.sh"]

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/__init__.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/__init__.py
@@ -1,0 +1,1 @@
+# Travel Tools MCP Server

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/dd_init.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/dd_init.py
@@ -1,0 +1,78 @@
+"""
+Datadog LLM Observability initialization for MCP Travel Tools server via OpenTelemetry.
+
+AgentCore integration approach (per PR #1097):
+- DISABLE_ADOT_OBSERVABILITY=true disables AgentCore's built-in ADOT/CloudWatch pipeline
+- OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental enables GenAI semantic conventions
+- A custom TracerProvider with OTLPSpanExporter sends traces directly to Datadog
+- dd-otlp-source=llmobs routes traces to Datadog LLM Observability views
+- DD_API_KEY is resolved from Secrets Manager at startup (via entrypoint.sh and here as backup)
+
+No ddtrace or Datadog Agent required — pure OTEL export to Datadog.
+
+Must be imported FIRST in every Python entry point (before any other imports).
+"""
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Disable AgentCore's built-in ADOT so we can set our own TracerProvider
+os.environ.setdefault("DISABLE_ADOT_OBSERVABILITY", "true")
+
+# Required for GenAI semantic conventions (v1.37+)
+os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
+
+
+def _resolve_dd_api_key():
+    """Resolve DD_API_KEY from Secrets Manager if not already set."""
+    secret_arn = os.environ.get("DD_API_KEY_SECRET_ARN")
+    if not secret_arn or os.environ.get("DD_API_KEY"):
+        return
+    try:
+        import boto3
+        client = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+        resp = client.get_secret_value(SecretId=secret_arn)
+        os.environ["DD_API_KEY"] = resp["SecretString"]
+        logger.info("DD_API_KEY resolved from Secrets Manager")
+    except Exception as e:
+        logger.error("Failed to resolve DD_API_KEY: %s", e)
+
+
+def _configure_datadog_otel():
+    """Configure OpenTelemetry TracerProvider to export traces to Datadog LLM Observability."""
+    dd_api_key = os.environ.get("DD_API_KEY", "")
+    dd_site = os.environ.get("DD_SITE", "datadoghq.com")
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "travel-mcp-server")
+
+    if not dd_api_key:
+        logger.warning("DD_API_KEY not set. Traces will not be sent to Datadog.")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({"service.name": service_name})
+        exporter = OTLPSpanExporter(
+            endpoint=f"https://trace.agent.{dd_site}/v1/traces",
+            headers={"dd-api-key": dd_api_key, "dd-otlp-source": "llmobs"},
+        )
+        provider = TracerProvider(resource=resource)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+
+        # Ensure spans are flushed on shutdown
+        import atexit
+        atexit.register(provider.shutdown)
+
+        logger.info("Datadog LLM Observability configured (service: %s)", service_name)
+    except Exception as e:
+        logger.error("Failed to configure Datadog OTEL: %s", e)
+
+
+_resolve_dd_api_key()
+_configure_datadog_otel()

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/entrypoint.sh
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Entrypoint for MCP travel tools — Datadog LLM Observability via pure OTEL.
+#
+# How it works:
+# 1. DD_API_KEY is resolved from Secrets Manager
+# 2. dd_init.py (imported first in server.py) configures an OTEL TracerProvider
+#    that exports traces directly to Datadog's OTLP endpoint
+# 3. DISABLE_ADOT_OBSERVABILITY=true prevents AgentCore's ADOT from conflicting
+#
+# No ddtrace or Datadog Agent required.
+
+if [ -n "$DD_API_KEY_SECRET_ARN" ] && [ -z "$DD_API_KEY" ]; then
+    echo "Resolving DD_API_KEY from Secrets Manager..."
+    export DD_API_KEY=$(python -c "
+import boto3, os
+client = boto3.client('secretsmanager', region_name=os.environ.get('AWS_REGION', 'us-east-1'))
+print(client.get_secret_value(SecretId=os.environ['DD_API_KEY_SECRET_ARN'])['SecretString'])
+" 2>/dev/null)
+    if [ -n "$DD_API_KEY" ]; then
+        echo "DD_API_KEY resolved successfully"
+    else
+        echo "WARNING: Failed to resolve DD_API_KEY from Secrets Manager"
+    fi
+fi
+
+exec python server.py

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/requirements.txt
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/requirements.txt
@@ -1,0 +1,6 @@
+boto3>=1.40.8
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp-proto-http>=1.20.0
+google-search-results>=2.4.2
+mcp>=1.23.3
+requests>=2.28.0

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/server.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/server.py
@@ -1,0 +1,134 @@
+"""
+Travel Tools MCP Server
+
+Exposes raw travel-related tools via MCP protocol.
+No agent logic - just pure tool implementations.
+"""
+
+import dd_init  # noqa: F401 - must be first import to configure OTEL TracerProvider
+import os
+import logging
+import boto3
+from typing import Optional
+from mcp.server import FastMCP
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Environment configuration
+REGION = os.getenv("AWS_REGION")
+if not REGION:
+    raise ValueError("AWS_REGION environment variable is required")
+
+# Initialize AWS clients
+ssm_client = boto3.client("ssm", region_name=REGION)
+
+# Create MCP server
+mcp = FastMCP(
+    "Travel Tools", host="0.0.0.0", stateless_http=True
+)  # nosec B104:standard pattern for containerized MCP serverss
+
+
+def get_ssm_parameter(parameter_name: str) -> str | None:
+    """Retrieve a parameter from SSM Parameter Store."""
+    try:
+        response = ssm_client.get_parameter(Name=parameter_name, WithDecryption=True)
+        return response["Parameter"]["Value"]
+    except Exception as e:
+        logger.warning(f"Could not retrieve SSM parameter {parameter_name}: {e}")
+        return None
+
+
+def load_api_keys():
+    """Load API keys from SSM and set as environment variables."""
+    keys = {
+        "SERP_API_KEY": "/concierge-agent/travel/serp-api-key",
+    }
+
+    for env_var, ssm_param in keys.items():
+        if not os.getenv(env_var):
+            value = get_ssm_parameter(ssm_param)
+            if value:
+                os.environ[env_var] = value
+                logger.info(f"✓ Loaded {env_var} from SSM")
+            else:
+                logger.warning(f"⚠️  {env_var} not configured")
+
+
+# Load API keys before importing tools
+load_api_keys()
+
+# Import tools after API keys are loaded
+from tools import (  # noqa: E402
+    serp_search_tool,
+    serp_hotel_search,
+    serp_flight_search,
+)
+
+
+# =============================================================================
+# MCP TOOLS - Raw tool exposure
+# =============================================================================
+
+
+@mcp.tool()
+def travel_search(query: str) -> str:
+    """
+    Search the internet for travel-related information.
+
+    Args:
+        query: Search query (e.g., "best restaurants in Rome", "Tokyo travel tips")
+
+    Returns:
+        Search results with titles, snippets, and source URLs.
+    """
+    return serp_search_tool(query)
+
+
+@mcp.tool()
+def travel_hotel_search(query: str, check_in_date: str, check_out_date: str) -> str:
+    """
+    Search for hotels using Google Hotels via SerpAPI.
+
+    Args:
+        query: Hotel search query (e.g., "fancy hotels in Paris",
+               "hotels near Times Square", "beachfront hotels in Miami")
+        check_in_date: Check-in date in YYYY-MM-DD format (e.g., "2025-12-20")
+        check_out_date: Check-out date in YYYY-MM-DD format (e.g., "2025-12-25")
+
+    Returns:
+        Formatted hotel results with ratings, prices, amenities, and booking links.
+    """
+    return serp_hotel_search(query, check_in_date, check_out_date)
+
+
+@mcp.tool()
+def travel_flight_search(
+    departure_id: str,
+    arrival_id: str,
+    outbound_date: str,
+    return_date: Optional[str] = None,
+) -> str:
+    """
+    Search for flights using Google Flights via SerpAPI.
+
+    Args:
+        departure_id: Departure airport code (e.g., "DCA", "JFK", "LAX")
+        arrival_id: Arrival airport code (e.g., "LGA", "SFO", "ORD")
+        outbound_date: Outbound flight date in YYYY-MM-DD format (e.g., "2025-12-20")
+        return_date: Return flight date in YYYY-MM-DD format (optional, omit for one-way)
+
+    Returns:
+        Formatted flight results with prices, durations, layovers, and carbon emissions.
+    """
+    return serp_flight_search(departure_id, arrival_id, outbound_date, return_date)
+
+
+# =============================================================================
+# SERVER STARTUP
+# =============================================================================
+
+if __name__ == "__main__":
+    logger.info("Starting Travel Tools MCP Server...")
+    mcp.run(transport="streamable-http")

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/tools.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/tools.py
@@ -1,0 +1,348 @@
+"""
+Travel Tools Implementation
+
+Pure tool functions for search, flights, and hotels via SerpAPI.
+No agent logic - these are called directly by the MCP server.
+"""
+
+import os
+import re
+from typing import Optional
+
+import requests
+from serpapi import GoogleSearch
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+REGION = os.getenv("AWS_REGION")
+SERP_API_KEY = os.getenv("SERP_API_KEY")
+
+
+# =============================================================================
+# SERP API TOOLS (Google Search, Hotels, Flights)
+# =============================================================================
+
+
+def serp_search_tool(query: str) -> str:
+    """Perform internet search using SerpAPI."""
+    if not SERP_API_KEY:
+        return "Error: SERP API key not configured."
+
+    try:
+        # Search using SerpAPI
+        params = {
+            "engine": "google",  # google_hotels, # google_flights
+            "q": query,
+            "api_key": SERP_API_KEY,
+        }
+
+        search = GoogleSearch(params)
+        response = search.get_dict()
+
+        if not response or "organic_results" not in response:
+            return "No search results found."
+
+        formatted = []
+        for i, result in enumerate(response["organic_results"], 1):
+            title = result.get("title", "No title")
+            snippet = result.get("snippet", "")[:200]
+            link = result.get("link", "")
+            source = result.get("source", "")
+
+            # Build formatted result
+            result_text = f"{i}. **{title}**"
+            if snippet:
+                result_text += f"\n   {snippet}"
+                if len(result.get("snippet", "")) > 200:
+                    result_text += "..."
+            if source:
+                result_text += f"\n   Source: {source}"
+            if link:
+                result_text += f"\n   URL: {link}"
+
+            formatted.append(result_text)
+
+        return "\n\n".join(formatted) if formatted else "No results found."
+
+    except Exception as e:
+        return f"Search error: {str(e)}"
+
+
+def serp_hotel_search(query: str, check_in_date: str, check_out_date: str) -> str:
+    """
+    Search for hotels using SerpAPI Google Hotels engine.
+
+    Args:
+        query: Hotel search query (e.g., "fancy hotels in Paris", "hotels near Times Square")
+        check_in_date: Check-in date in YYYY-MM-DD format
+        check_out_date: Check-out date in YYYY-MM-DD format
+
+    Returns:
+        Formatted string with hotel results
+    """
+    if not SERP_API_KEY:
+        return "Error: SERP API key not configured."
+
+    try:
+        # Search hotels using SerpAPI
+        params = {
+            "engine": "google_hotels",
+            "q": query,
+            "check_in_date": check_in_date,
+            "check_out_date": check_out_date,
+            "api_key": SERP_API_KEY,
+        }
+
+        search = GoogleSearch(params)
+        response = search.get_dict()
+
+        if not response or "properties" not in response:
+            return "No hotel results found."
+
+        formatted = []
+        for i, hotel in enumerate(response["properties"][:10], 1):  # Limit to top 10
+            name = hotel.get("name", "No name")
+
+            # Build formatted result
+            result_text = f"{i}. **{name}**"
+
+            # Hotel class (star rating)
+            hotel_class = hotel.get("hotel_class")
+            if hotel_class:
+                try:
+                    # Extract numeric value from strings like "3-star hotel" or just "3"
+                    if isinstance(hotel_class, str):
+                        # Try to extract the first number from the string
+                        match = re.search(r"\d+", hotel_class)
+                        if match:
+                            stars = int(match.group())
+                            result_text += f" {'⭐' * stars}"
+                    else:
+                        # If it's already a number, use it directly
+                        result_text += f" {'⭐' * int(hotel_class)}"
+                except (ValueError, TypeError):
+                    # If conversion fails, just show the text
+                    result_text += f" ({hotel_class})"
+
+            # Rating
+            rating = hotel.get("overall_rating")
+            reviews = hotel.get("reviews")
+            if rating:
+                result_text += f"\n   Rating: {rating}"
+                if reviews:
+                    result_text += f" ({reviews} reviews)"
+
+            # Price per night
+            rate = hotel.get("rate_per_night")
+            if rate:
+                lowest = rate.get("extracted_lowest")
+                highest = rate.get("extracted_highest")
+                if lowest and highest:
+                    result_text += f"\n   Price: ${lowest} - ${highest} per night"
+                elif lowest:
+                    result_text += f"\n   Price: ${lowest} per night"
+
+            # Description
+            description = hotel.get("description", "")
+            if description:
+                # Truncate description to 150 characters
+                desc_short = description[:150]
+                if len(description) > 150:
+                    desc_short += "..."
+                result_text += f"\n   {desc_short}"
+
+            # Amenities (if available)
+            amenities = hotel.get("amenities", [])
+            if amenities and len(amenities) > 0:
+                # Show first 3 amenities
+                amenities_str = ", ".join(amenities[:3])
+                result_text += f"\n   Amenities: {amenities_str}"
+                if len(amenities) > 3:
+                    result_text += f" (+{len(amenities) - 3} more)"
+
+            # Link
+            link = hotel.get("link")
+            if link:
+                result_text += f"\n   URL: {link}"
+
+            formatted.append(result_text)
+
+        header = f"Hotel Search Results for '{query}' ({check_in_date} to {check_out_date}):\n\n"
+        return (
+            header + "\n\n".join(formatted) if formatted else "No hotel results found."
+        )
+
+    except Exception as e:
+        return f"Hotel search error: {str(e)}"
+
+
+def serp_flight_search(
+    departure_id: str,
+    arrival_id: str,
+    outbound_date: str,
+    return_date: Optional[str] = None,
+) -> str:
+    """
+    Search for flights using SerpAPI Google Flights engine.
+
+    Args:
+        departure_id: Departure airport code (e.g., "DCA", "JFK")
+        arrival_id: Arrival airport code (e.g., "LGA", "LAX")
+        outbound_date: Outbound flight date in YYYY-MM-DD format
+        return_date: Return flight date in YYYY-MM-DD format (optional, omit for one-way)
+
+    Returns:
+        Formatted string with flight results
+    """
+    if not SERP_API_KEY:
+        return "Error: SERP API key not configured."
+
+    try:
+        # Search flights using SerpAPI
+        params = {
+            "engine": "google_flights",
+            "departure_id": departure_id,
+            "arrival_id": arrival_id,
+            "outbound_date": outbound_date,
+            "api_key": SERP_API_KEY,
+        }
+
+        # Add return date if provided
+        if return_date:
+            params["return_date"] = return_date
+
+        search = GoogleSearch(params)
+        results = search.get_dict()
+
+        if not results:
+            return "No flight results found."
+
+        formatted = []
+
+        # Process best flights
+        best_flights = results.get("best_flights", [])
+        if best_flights:
+            formatted.append("=== Best Flights ===\n")
+            for i, flight in enumerate(best_flights, 1):
+                result_text = f"{i}. "
+
+                # Flight segments
+                segments = []
+                for segment in flight.get("flights", []):
+                    dep_airport = segment.get("departure_airport", {})
+                    arr_airport = segment.get("arrival_airport", {})
+                    airline = segment.get("airline", "Unknown")
+                    flight_num = segment.get("flight_number", "")
+
+                    seg_text = f"{airline} {flight_num}: {dep_airport.get('id', '')} ({dep_airport.get('time', '')}) → {arr_airport.get('id', '')} ({arr_airport.get('time', '')})"
+                    segments.append(seg_text)
+
+                result_text += "\n   ".join(segments)
+
+                # Price and duration
+                price = flight.get("price")
+                total_duration = flight.get("total_duration")
+                if price:
+                    result_text += f"\n   Price: ${price}"
+                if total_duration:
+                    hours = total_duration // 60
+                    minutes = total_duration % 60
+                    result_text += f" | Duration: {hours}h {minutes}m"
+
+                # Layovers
+                layovers = flight.get("layovers", [])
+                if layovers:
+                    layover_details = []
+                    for layover in layovers:
+                        duration = layover.get("duration", 0)
+                        hours = duration // 60
+                        minutes = duration % 60
+                        layover_details.append(
+                            f"{layover.get('id', 'Unknown')} ({hours}h {minutes}m)"
+                        )
+                    result_text += f"\n   Layovers: {', '.join(layover_details)}"
+
+                # Carbon emissions
+                carbon = flight.get("carbon_emissions", {})
+                if carbon:
+                    diff = carbon.get("difference_percent", 0)
+                    this_flight = carbon.get("this_flight", 0) / 1000  # Convert to kg
+                    result_text += (
+                        f"\n   Carbon: {this_flight:.0f} kg ({diff:+d}% vs typical)"
+                    )
+
+                formatted.append(result_text)
+
+        # Process other flights
+        other_flights = results.get("other_flights", [])
+        if other_flights:
+            if formatted:
+                formatted.append("\n\n=== Other Flights ===\n")
+
+            for i, flight in enumerate(other_flights[:10], 1):
+                result_text = f"{i}. "
+
+                # Flight segments
+                segments = []
+                for segment in flight.get("flights", []):
+                    dep_airport = segment.get("departure_airport", {})
+                    arr_airport = segment.get("arrival_airport", {})
+                    airline = segment.get("airline", "Unknown")
+                    flight_num = segment.get("flight_number", "")
+
+                    seg_text = f"{airline} {flight_num}: {dep_airport.get('id', '')} ({dep_airport.get('time', '')}) → {arr_airport.get('id', '')} ({arr_airport.get('time', '')})"
+                    segments.append(seg_text)
+
+                result_text += "\n   ".join(segments)
+
+                # Price and duration
+                price = flight.get("price")
+                total_duration = flight.get("total_duration")
+                if price:
+                    result_text += f"\n   Price: ${price}"
+                if total_duration:
+                    hours = total_duration // 60
+                    minutes = total_duration % 60
+                    result_text += f" | Duration: {hours}h {minutes}m"
+
+                # Layovers
+                layovers = flight.get("layovers", [])
+                if layovers:
+                    layover_details = []
+                    for layover in layovers:
+                        duration = layover.get("duration", 0)
+                        hours = duration // 60
+                        minutes = duration % 60
+                        layover_details.append(
+                            f"{layover.get('id', 'Unknown')} ({hours}h {minutes}m)"
+                        )
+                    result_text += f"\n   Layovers: {', '.join(layover_details)}"
+
+                # Carbon emissions
+                carbon = flight.get("carbon_emissions", {})
+                if carbon:
+                    diff = carbon.get("difference_percent", 0)
+                    this_flight = carbon.get("this_flight", 0) / 1000  # Convert to kg
+                    result_text += (
+                        f"\n   Carbon: {this_flight:.0f} kg ({diff:+d}% vs typical)"
+                    )
+
+                formatted.append(result_text)
+
+        if not formatted:
+            return "No flight results found."
+
+        # Build header
+        trip_type = "Round-trip" if return_date else "One-way"
+        header = f"Flight Search Results ({trip_type}): {departure_id} → {arrival_id}\n"
+        header += f"Outbound: {outbound_date}"
+        if return_date:
+            header += f" | Return: {return_date}"
+        header += "\n\n"
+
+        return header + "\n\n".join(formatted)
+
+    except Exception as e:
+        return f"Flight search error: {str(e)}"

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/tools.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/mcp_travel_tools/tools.py
@@ -17,7 +17,11 @@ from serpapi import GoogleSearch
 # =============================================================================
 
 REGION = os.getenv("AWS_REGION")
-SERP_API_KEY = os.getenv("SERP_API_KEY")
+
+
+def _get_serp_api_key() -> str | None:
+    """Lazy getter so the key is read after SSM loads it into the environment."""
+    return os.getenv("SERP_API_KEY")
 
 
 # =============================================================================
@@ -27,7 +31,8 @@ SERP_API_KEY = os.getenv("SERP_API_KEY")
 
 def serp_search_tool(query: str) -> str:
     """Perform internet search using SerpAPI."""
-    if not SERP_API_KEY:
+    serp_api_key = _get_serp_api_key()
+    if not serp_api_key:
         return "Error: SERP API key not configured."
 
     try:
@@ -35,7 +40,7 @@ def serp_search_tool(query: str) -> str:
         params = {
             "engine": "google",  # google_hotels, # google_flights
             "q": query,
-            "api_key": SERP_API_KEY,
+            "api_key": serp_api_key,
         }
 
         search = GoogleSearch(params)
@@ -82,7 +87,7 @@ def serp_hotel_search(query: str, check_in_date: str, check_out_date: str) -> st
     Returns:
         Formatted string with hotel results
     """
-    if not SERP_API_KEY:
+    if not _get_serp_api_key():
         return "Error: SERP API key not configured."
 
     try:
@@ -92,7 +97,7 @@ def serp_hotel_search(query: str, check_in_date: str, check_out_date: str) -> st
             "q": query,
             "check_in_date": check_in_date,
             "check_out_date": check_out_date,
-            "api_key": SERP_API_KEY,
+            "api_key": _get_serp_api_key(),
         }
 
         search = GoogleSearch(params)
@@ -196,7 +201,7 @@ def serp_flight_search(
     Returns:
         Formatted string with flight results
     """
-    if not SERP_API_KEY:
+    if not _get_serp_api_key():
         return "Error: SERP API key not configured."
 
     try:
@@ -206,7 +211,7 @@ def serp_flight_search(
             "departure_id": departure_id,
             "arrival_id": arrival_id,
             "outbound_date": outbound_date,
-            "api_key": SERP_API_KEY,
+            "api_key": _get_serp_api_key(),
         }
 
         # Add return date if provided

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/.dockerignore
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/.dockerignore
@@ -1,0 +1,68 @@
+# Build artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Python cache
+__pycache__/
+__pycache__*
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+.venv/
+.env
+venv/
+env/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage*
+htmlcov/
+.tox/
+*.cover
+.hypothesis/
+.mypy_cache/
+.ruff_cache/
+
+# Development
+*.log
+*.bak
+*.swp
+*.swo
+*~
+.DS_Store
+
+# IDEs
+.vscode/
+.idea/
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Project specific
+tests/
+
+# Bedrock AgentCore specific - keep config but exclude runtime files
+.bedrock_agentcore.yaml
+.dockerignore
+
+# Keep wheelhouse for offline installations
+# wheelhouse/

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/Dockerfile
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/Dockerfile
@@ -1,0 +1,50 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+WORKDIR /app
+
+# Configure UV for container environment
+ENV UV_SYSTEM_PYTHON=1 UV_COMPILE_BYTECODE=1
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN uv pip install -r requirements.txt
+
+# Set environment variables
+ENV AWS_REGION=us-east-1
+ENV AWS_DEFAULT_REGION=us-east-1
+ENV DOCKER_CONTAINER=1
+ENV PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Datadog LLM Observability via pure OTEL (no ddtrace agent required)
+# strands-agents[otel] emits OTEL GenAI spans; dd_init.py configures TracerProvider
+ENV DD_SITE=datadoghq.com
+ENV OTEL_SERVICE_NAME=supervisor-agent
+
+# Disable AgentCore's built-in ADOT — using Datadog OTEL instead
+ENV DISABLE_ADOT_OBSERVABILITY=true
+
+# Required for strands-agents GenAI semantic conventions (v1.37+)
+ENV OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+
+# Copy application code
+COPY . .
+
+# Make entrypoint executable
+RUN chmod +x entrypoint.sh
+
+# Create non-root user
+RUN useradd -m -u 1000 bedrock_agentcore && \
+    chown -R bedrock_agentcore:bedrock_agentcore /app
+USER bedrock_agentcore
+
+# Expose ports
+EXPOSE 8080
+EXPOSE 8000
+
+# Add HEALTHCHECK 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD pgrep -f "python agent.py" || exit 1
+
+# Run the agent — entrypoint resolves DD_API_KEY, dd_init.py configures OTEL
+CMD ["bash", "entrypoint.sh"]

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/__init__.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/__init__.py
@@ -1,0 +1,7 @@
+"""
+Strands Agent Package
+
+This package contains specialized agents for travel planning assistance.
+"""
+
+__version__ = "1.0.0"

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/agent.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/agent.py
@@ -1,0 +1,193 @@
+import dd_init  # noqa: F401 - must be first import to configure OTEL TracerProvider
+import os
+import logging
+import boto3
+from botocore.config import Config
+from strands import Agent
+from strands.models import BedrockModel
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from bedrock_agentcore.memory.integrations.strands.session_manager import (
+    AgentCoreMemorySessionManager,
+)
+from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig
+import json
+import traceback
+
+# Import local modules
+from prompt_manager import get_prompt
+from dynamodb_manager import DynamoDBManager
+from gateway_client import get_gateway_client
+from travel_subagent import travel_assistant
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+app = BedrockAgentCoreApp(middleware=[])
+
+# Enable CORS for local development (port 9000 matches web-ui vite.config.ts)
+app.cors_allow_origins = ["https://localhost:9000"]
+app.cors_allow_methods = ["GET", "POST", "OPTIONS"]
+app.cors_allow_headers = ["Content-Type", "Authorization"]
+
+REGION = os.getenv("AWS_REGION")
+MEMORY_ID = os.getenv("MEMORY_ID")
+ITINERARY_TABLE_NAME = os.getenv("ITINERARY_TABLE_NAME")
+
+logger.info(f"🗂️  Using Itinerary table: {ITINERARY_TABLE_NAME}")
+
+# DynamoDB setup for itinerary
+dynamodb = boto3.resource("dynamodb", region_name=REGION)
+
+# Initialize bedrock model - Claude 4.5 Sonnet for routing/coordination
+bedrock_model = BedrockModel(
+    model_id="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    region_name=REGION,
+    temperature=0.1,
+    max_tokens=4096,
+    boto_client_config=Config(retries={"mode": "adaptive", "max_attempts": 5}),
+)
+
+
+def get_user_profile_data(user_id: str) -> str:
+    """Get user profile data formatted for prompts."""
+    try:
+        manager = DynamoDBManager(region_name=REGION)
+        profile = manager.get_user_profile(user_id)
+
+        if not profile:
+            return "User profile not available"
+
+        # Extract profile information
+        profile_parts = []
+
+        # IMPORTANT: Always include userId first - this is the user's unique identifier
+        if profile.get("userId"):
+            profile_parts.append(
+                f"User ID (use this for all tool calls): {profile['userId']}"
+            )
+
+        if profile.get("name"):
+            profile_parts.append(f"Name: {profile['name']}")
+
+        if profile.get("email"):
+            profile_parts.append(f"Email: {profile['email']}")
+
+        if profile.get("address"):
+            profile_parts.append(f"Address: {profile['address']}")
+
+        if profile.get("notes"):
+            profile_parts.append(f"Notes: {profile['notes']}")
+
+        if profile.get("preferences"):
+            preferences = profile["preferences"]
+            if isinstance(preferences, str):
+                try:
+                    prefs = json.loads(preferences)
+                    profile_parts.append(f"Preferences: {json.dumps(prefs)}")
+                except json.JSONDecodeError:
+                    profile_parts.append(f"Preferences: {preferences}")
+            else:
+                profile_parts.append(f"Preferences: {preferences}")
+
+        if profile.get("onboardingCompleted"):
+            profile_parts.append(
+                f"Onboarding completed: {profile['onboardingCompleted']}"
+            )
+
+        if profile_parts:
+            profile_text = f", Profile: {'; '.join(profile_parts)}"
+        else:
+            profile_text = ", Profile: Basic user profile available"
+
+        return profile_text
+
+    except Exception as e:
+        logger.error(f"Error getting user profile: {e}")
+        return "User profile not available"
+
+
+def create_supervisor_agent(user_id: str, session_id: str) -> Agent:
+    """Create supervisor agent with AgentCore memory session manager."""
+    # Get user profile data
+    try:
+        user_profile = get_user_profile_data(user_id)
+        logger.info(f"Retrieved user profile for {user_id}: {user_profile[:200]}...")
+    except Exception as e:
+        logger.warning(f"Could not retrieve user profile for {user_id}: {e}")
+        user_profile = "User profile not available"
+
+    # Get base prompt and add user profile context
+    base_prompt = get_prompt("travel_agent_supervisor").format(
+        user_profile=user_profile
+    )
+
+    # Configure AgentCore Memory integration
+    agentcore_memory_config = AgentCoreMemoryConfig(
+        memory_id=MEMORY_ID, session_id=session_id, actor_id=f"supervisor-{user_id}"
+    )
+
+    session_manager = AgentCoreMemorySessionManager(
+        agentcore_memory_config=agentcore_memory_config, region_name=REGION
+    )
+
+    logger.info("Creating supervisor agent with session manager...")
+
+    # Get Gateway MCP client for itinerary tools
+    logger.info("Setting up Gateway MCP client...")
+    itinerary_client = get_gateway_client("^itinerarytools___")
+
+    # Create agent with itinerary tools and subagents
+    agent = Agent(
+        name="supervisor_agent",
+        system_prompt=base_prompt,
+        tools=[itinerary_client, travel_assistant],
+        model=bedrock_model,
+        session_manager=session_manager,
+        trace_attributes={
+            "user.id": user_id,
+            "session.id": session_id,
+        },
+    )
+    logger.info("✅ Agent created with itinerary tools and travel subagent")
+
+    logger.info("Supervisor agent created successfully with session manager")
+    return agent
+
+
+@app.entrypoint
+async def agent_stream(payload):
+    """Main entrypoint for the supervisor agent with session manager."""
+    user_query = payload.get("prompt")
+    user_id = payload.get("user_id")
+    session_id = payload.get("session_id")
+
+    if not all([user_query, user_id, session_id]):
+        yield {
+            "status": "error",
+            "error": "Missing required fields: prompt, user_id, or session_id",
+        }
+        return
+
+    try:
+        logger.info(
+            f"Starting streaming invocation for user: {user_id}, session: {session_id}"
+        )
+        logger.info(f"Query: {user_query}")
+
+        agent = create_supervisor_agent(user_id, session_id)
+
+        # Use the agent's stream_async method for true token-level streaming
+        async for event in agent.stream_async(user_query):
+            yield event
+
+    except Exception as e:
+        logger.error(f"Error in agent_stream: {e}")
+        traceback.print_exc()
+        yield {"status": "error", "error": str(e)}
+
+
+if __name__ == "__main__":
+    app.run()

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/dd_init.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/dd_init.py
@@ -1,0 +1,83 @@
+"""
+Datadog LLM Observability initialization via OpenTelemetry.
+
+AgentCore integration approach (per PR #1097):
+- DISABLE_ADOT_OBSERVABILITY=true disables AgentCore's built-in ADOT/CloudWatch pipeline
+- OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental enables GenAI semantic conventions
+- A custom TracerProvider with OTLPSpanExporter sends traces directly to Datadog
+- dd-otlp-source=llmobs routes traces to Datadog LLM Observability views
+- strands-agents[otel] automatically emits OTEL spans when a TracerProvider is set
+- DD_API_KEY is resolved from Secrets Manager at startup (via entrypoint.sh and here as backup)
+
+No ddtrace or Datadog Agent required — pure OTEL export to Datadog.
+
+Must be imported FIRST in every Python entry point (before any other imports).
+"""
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Disable AgentCore's built-in ADOT so we can set our own TracerProvider
+# See: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html
+os.environ.setdefault("DISABLE_ADOT_OBSERVABILITY", "true")
+
+# Required for strands-agents GenAI semantic conventions (v1.37+)
+os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
+
+
+def _resolve_dd_api_key():
+    """Resolve DD_API_KEY from Secrets Manager if not already set."""
+    secret_arn = os.environ.get("DD_API_KEY_SECRET_ARN")
+    if not secret_arn or os.environ.get("DD_API_KEY"):
+        return
+    try:
+        import boto3
+        client = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+        resp = client.get_secret_value(SecretId=secret_arn)
+        os.environ["DD_API_KEY"] = resp["SecretString"]
+        logger.info("DD_API_KEY resolved from Secrets Manager")
+    except Exception as e:
+        logger.error("Failed to resolve DD_API_KEY: %s", e)
+
+
+def _configure_datadog_otel():
+    """Configure OpenTelemetry TracerProvider to export traces to Datadog LLM Observability."""
+    dd_api_key = os.environ.get("DD_API_KEY", "")
+    dd_site = os.environ.get("DD_SITE", "datadoghq.com")
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "supervisor-agent")
+
+    if not dd_api_key:
+        logger.warning("DD_API_KEY not set. Traces will not be sent to Datadog.")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({"service.name": service_name})
+        exporter = OTLPSpanExporter(
+            endpoint=f"https://trace.agent.{dd_site}/v1/traces",
+            headers={"dd-api-key": dd_api_key, "dd-otlp-source": "llmobs"},
+        )
+        provider = TracerProvider(resource=resource)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+
+        # Ensure spans are flushed on shutdown
+        import atexit
+        atexit.register(provider.shutdown)
+
+        logger.info("Datadog LLM Observability configured (service: %s)", service_name)
+    except Exception as e:
+        logger.error("Failed to configure Datadog OTEL: %s", e)
+
+
+# Execution order:
+# 1. Resolve DD_API_KEY from Secrets Manager
+# 2. Configure OTEL TracerProvider → Datadog OTLP intake
+_resolve_dd_api_key()
+_configure_datadog_otel()

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/dynamodb_manager.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/dynamodb_manager.py
@@ -1,0 +1,59 @@
+import os
+import boto3
+from botocore.exceptions import ClientError
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class DynamoDBManager:
+    """DynamoDB client for user profile operations."""
+
+    def __init__(self, region_name: str = None):
+        self.region_name = region_name or os.environ.get("AWS_REGION")
+
+        # Initialize DynamoDB resource
+        self.dynamodb = boto3.resource("dynamodb", region_name=self.region_name)
+
+        # Table names from environment variables
+        self.user_profile_table_name = os.environ.get("USER_PROFILE_TABLE_NAME")
+
+        # Get table reference
+        self.user_profile_table = self.dynamodb.Table(self.user_profile_table_name)
+
+        logger.info(f"DynamoDB Manager initialized with region: {self.region_name}")
+        logger.info(f"UserProfile table: {self.user_profile_table_name}")
+
+    def get_user_profile(self, user_id: str):
+        """Get user profile from the UserProfile table."""
+        try:
+            # Look up by id (primary key)
+            response = self.user_profile_table.get_item(Key={"id": user_id})
+
+            if "Item" in response:
+                profile = response["Item"]
+                logger.info(f"Retrieved user profile for: {user_id}")
+                return profile
+
+            # NOTE: Table scan is expensive at scale. If userId lookups are common,
+            # add a GSI on the userId attribute to avoid full-table scans.
+            logger.warning(f"Primary key miss for {user_id}, falling back to scan")
+            response = self.user_profile_table.scan(
+                FilterExpression="userId = :user_id",
+                ExpressionAttributeValues={":user_id": user_id},
+                Limit=1,
+            )
+
+            items = response.get("Items", [])
+            if items:
+                profile = items[0]
+                logger.info(f"Retrieved user profile via userId scan for: {user_id}")
+                return profile
+            else:
+                logger.info(f"No user profile found for: {user_id}")
+                return None
+
+        except ClientError as e:
+            logger.error(f"Error getting user profile: {e}")
+            raise

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/entrypoint.sh
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Entrypoint for supervisor agent — Datadog LLM Observability via pure OTEL.
+#
+# How it works:
+# 1. DD_API_KEY is resolved from Secrets Manager
+# 2. dd_init.py (imported first in agent.py) configures an OTEL TracerProvider
+#    that exports traces directly to Datadog's OTLP endpoint
+# 3. strands-agents[otel] automatically emits GenAI spans via that TracerProvider
+# 4. DISABLE_ADOT_OBSERVABILITY=true prevents AgentCore's ADOT from conflicting
+#
+# No ddtrace or Datadog Agent required.
+
+if [ -n "$DD_API_KEY_SECRET_ARN" ] && [ -z "$DD_API_KEY" ]; then
+    echo "Resolving DD_API_KEY from Secrets Manager..."
+    export DD_API_KEY=$(python -c "
+import boto3, os
+client = boto3.client('secretsmanager', region_name=os.environ.get('AWS_REGION', 'us-east-1'))
+print(client.get_secret_value(SecretId=os.environ['DD_API_KEY_SECRET_ARN'])['SecretString'])
+" 2>/dev/null)
+    if [ -n "$DD_API_KEY" ]; then
+        echo "DD_API_KEY resolved successfully"
+    else
+        echo "WARNING: Failed to resolve DD_API_KEY from Secrets Manager"
+    fi
+fi
+
+exec python agent.py

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/gateway_client.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/gateway_client.py
@@ -1,0 +1,67 @@
+"""
+Gateway client utilities for AgentCore Gateway integration.
+"""
+
+import os
+import re
+import boto3
+import logging
+from strands.tools.mcp import MCPClient
+from mcp.client.streamable_http import streamablehttp_client
+
+logger = logging.getLogger(__name__)
+
+
+def get_ssm_parameter(parameter_name: str, region: str) -> str:
+    """
+    Fetch parameter from SSM Parameter Store.
+
+    Args:
+        parameter_name: SSM parameter name
+        region: AWS region
+
+    Returns:
+        Parameter value
+    """
+    ssm = boto3.client("ssm", region_name=region)
+    try:
+        response = ssm.get_parameter(Name=parameter_name)
+        return response["Parameter"]["Value"]
+    except ssm.exceptions.ParameterNotFound:
+        raise ValueError(f"SSM parameter not found: {parameter_name}")
+    except Exception as e:
+        raise ValueError(f"Failed to retrieve SSM parameter {parameter_name}: {e}")
+
+
+def get_gateway_client(tool_filter_pattern: str, prefix: str = "gateway") -> MCPClient:
+    """
+    Get Gateway MCP client with specified tool filtering.
+
+    Args:
+        tool_filter_pattern: Regex pattern to filter tools (e.g., "^traveltools___")
+        prefix: Prefix for tool names (default: "gateway")
+
+    Returns:
+        MCPClient filtered to specified tools
+    """
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    deployment_id = os.getenv("DEPLOYMENT_ID", "default")
+
+    gateway_url = get_ssm_parameter(
+        f"/concierge-agent/{deployment_id}/gateway-url", region
+    )
+
+    logger.info(
+        f"Creating Gateway MCP client with filter: {tool_filter_pattern}, prefix: {prefix}"
+    )
+
+    tool_filters = {"allowed": [re.compile(tool_filter_pattern)]}
+
+    client = MCPClient(
+        lambda: streamablehttp_client(url=gateway_url),
+        prefix=prefix,
+        tool_filters=tool_filters,
+    )
+
+    logger.info(f"✅ Gateway MCP client created with filter: {tool_filter_pattern}")
+    return client

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/prompt_manager.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/prompt_manager.py
@@ -1,0 +1,62 @@
+"""
+Simple Prompt Manager
+Just a dictionary of prompts with a get function.
+"""
+
+import datetime
+import pytz
+
+# Get current date in Pacific time
+now_pt = datetime.datetime.now(tz=pytz.utc).astimezone(pytz.timezone("US/Pacific"))
+date_readable = now_pt.strftime("%B %d, %Y")  # e.g., "December 18, 2025"
+current_year = now_pt.year
+
+
+# Dictionary of all prompts
+PROMPTS = {
+    "travel_agent_supervisor": f"""
+You are a team supervisor managing multiple specialized agents. Your role is to coordinate their efforts and ensure the user receives accurate, helpful responses.
+Today's date is {date_readable}. Current year is {current_year}.
+
+CRITICAL DATE RULES - NEVER ALLOW BOOKINGS IN THE PAST:
+- NEVER create itineraries, book flights, or search for hotels for dates in the past
+- ALL travel bookings must be for TODAY ({date_readable}) or future dates only
+- When a user mentions a date without a year (e.g., "2/20"), interpret it as the NEXT future occurrence of that date
+- If the month/day has already passed this year, assume the user means next year ({current_year + 1})
+- Before routing to travel_assistant_agent, verify the requested date is not in the past 
+
+AGENT RESPONSIBILITIES:
+- travel_assistant_agent: Destination information, itineraries, travel tips, accommodation recommendations, weather forecasts, events
+
+ROUTING GUIDELINES:
+1. ALWAYS maintain context between agent transfers
+2. For multi-part queries, break them down and route each part to the appropriate agent
+3. For travel destination information, ALWAYS route to travel_assistant_agent
+4. NEVER allow agents to perform tasks outside their domain
+5. Do NOT automatically save travel recommendations to itinerary. Only save to itinerary when user EXPLICITLY requests it (e.g., "save this itinerary", "remember this for my trip", "add to my travel plan"). Travel recommendations are for browsing - itinerary is for saving.
+6. Anything pertaining to saving, clearing, or editing the itinerary you handle directly, you have the tools for itinerary management.
+7. For Itineraries, don't group everything into a single day, add individual itinerary items, just make sure to add a date, the itinerary tool will manage the grouping itself.
+8. IMPORTANT: When saving itinerary items, ALWAYS include the time_of_day parameter with one of these values: 'morning', 'afternoon', or 'evening'. This helps organize the user's day properly. Use context clues from the activity or user's request to determine the appropriate time of day (e.g., breakfast → morning, dinner → evening, museum visit → afternoon).
+9. CRITICAL: Before saving ANY itinerary item, verify the date is TODAY ({date_readable}) or in the FUTURE. NEVER save items with dates in the past. If a date appears to be in the past, do NOT save it - instead ask the user to clarify.
+
+COORDINATION RULES:
+1. When a query requires multiple agents, create a clear sequence of operations
+2. Validate agent responses before presenting to the user
+3. If an agent provides incorrect or hallucinated information, correct it before responding
+4. Maintain a clear separation between travel recommendations and product searches
+5. Include hyperlinks to search references in your responses, when appropriate.
+
+USER PROFILE:
+{{user_profile}}
+
+Use this profile data to:
+1. Inform routing and agent coordination decisions
+2. Enhance response relevance and personalization
+3. Share with sub-agents only when needed
+""",
+}
+
+
+def get_prompt(prompt_name):
+    """Get a prompt by name"""
+    return PROMPTS.get(prompt_name, None)

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/requirements.txt
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/requirements.txt
@@ -1,0 +1,12 @@
+bedrock-agentcore>=0.1.2
+bedrock-agentcore-starter-toolkit>=0.1.6
+boto3>=1.40.8
+pydantic>=2.0.0
+pydantic-core>=2.33.2
+pytz>=2025.2
+requests>=2.28.0
+requests-aws4auth>=1.3.1
+strands-agents[otel]>=1.4.0
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp-proto-http>=1.20.0
+mcp

--- a/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/travel_subagent.py
+++ b/datadog/samples/travel-concierge-agent-observability/concierge_agent/supervisor_agent/travel_subagent.py
@@ -1,0 +1,162 @@
+"""
+Travel Subagent
+
+A subagent that handles travel-related queries by connecting to travel tools
+via the gateway. Exposed as a tool for the main supervisor agent.
+"""
+
+import os
+import logging
+from datetime import datetime
+from strands import Agent, tool
+from strands.models import BedrockModel
+from botocore.config import Config
+from strands.tools.mcp import MCPClient
+
+from gateway_client import get_gateway_client
+
+logger = logging.getLogger(__name__)
+
+REGION = os.getenv("AWS_REGION", "us-east-1")
+
+# =============================================================================
+# TRAVEL AGENT SYSTEM PROMPT
+# =============================================================================
+
+TRAVEL_AGENT_PROMPT = """
+You are a travel assistant designed to help users plan trips and prepare for travel.
+For reference, today's date is {today_date}.
+
+Your primary responsibilities include:
+1. Providing destination information and itinerary recommendations
+2. Finding flights and hotels
+3. Searching for restaurants and attractions
+4. Providing up-to-date travel information via internet search
+
+You have access to the following tools:
+- `travel_search`: Find up-to-date information from the internet (including weather)
+- `travel_flight_search`: Search for flights (departure_id, arrival_id, outbound_date, optional return_date)
+- `travel_hotel_search`: Search for hotels (query, check_in_date, check_out_date)
+
+IMPORTANT GUIDELINES:
+
+1. Focus on the current query - maintain context from conversation history when relevant
+2. For weather questions, use travel_search to find current weather information
+3. For flight searches, ask for origin, destination, and dates if not provided
+4. For hotel searches, ask for city, check-in/check-out dates if not provided
+5. Categorize event/attraction results by type (cultural, sports, dining, etc.)
+6. Include dates, times, and locations for events and attractions
+7. Provide specific, actionable recommendations
+
+ITINERARY REQUIREMENTS (CRITICAL):
+- ALWAYS include at least 2-3 restaurant recommendations per day in multi-day itineraries
+- For restaurants, use travel_search to find specific options with addresses
+
+RETRY STRATEGY:
+- If a search returns no results or irrelevant results, retry with a refined query
+- Try different query phrasings (e.g., "restaurants in Tokyo" vs "best dining Tokyo")
+- For places search, try broader or more specific terms
+- For flights/hotels, verify airport codes and date formats are correct
+- Make up to 3 attempts before reporting no results found
+
+When responding:
+- Be clear and concise
+- Include relevant details like prices, ratings, and locations
+- Cite sources when using internet search results
+- Ask clarifying questions when needed
+- Format responses in an easy-to-read manner
+
+Your goal is to help users plan successful and enjoyable trips.
+"""
+
+
+# =============================================================================
+# GATEWAY CLIENT FOR TRAVEL TOOLS
+# =============================================================================
+
+
+def get_travel_tools_client() -> MCPClient:
+    """Get MCPClient filtered for travel tools only."""
+    return get_gateway_client("^traveltools___")
+
+
+# =============================================================================
+# BEDROCK MODEL
+# =============================================================================
+
+bedrock_model = BedrockModel(
+    model_id="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    region_name=REGION,
+    temperature=0.2,
+    max_tokens=4096,
+    boto_client_config=Config(retries={"mode": "adaptive", "max_attempts": 5}),
+)
+
+
+# =============================================================================
+# TRAVEL SUBAGENT TOOL
+# =============================================================================
+
+
+@tool
+async def travel_assistant(query: str, user_id: str = "", session_id: str = ""):
+    """
+    Process travel planning queries using specialized travel tools.
+
+    AVAILABLE TOOLS:
+    - travel_search: Internet search for travel info (query)
+    - travel_hotel_search: Search hotels (query, check_in_date YYYY-MM-DD, check_out_date YYYY-MM-DD)
+    - travel_flight_search: Search flights (departure_id, arrival_id as airport codes, outbound_date YYYY-MM-DD, optional return_date)
+
+    ROUTE HERE FOR:
+    - Flight searches: "Find flights from BOS to PAR on 2025-12-20"
+    - Hotel searches: "Hotels in Rome from 2025-12-20 to 2025-12-25"
+    - Restaurant/attraction searches: "Best sushi restaurants in Tokyo"
+    - General travel info: "What to do in Barcelona", "Travel tips for Japan"
+    - Trip planning: "Plan a 3-day itinerary for Madrid"
+
+    IMPORTANT: Include specific dates (YYYY-MM-DD format) and airport codes when available.
+    For flights, use 3-letter airport codes (BOS, JFK, CDG, NRT, etc.).
+
+    Args:
+        query: The travel request with as much detail as possible.
+        user_id: User identifier for personalization.
+        session_id: Session identifier for context.
+
+    Returns:
+        Travel information, search results, or recommendations.
+        Will retry searches with refined queries if initial results are insufficient.
+    """
+    try:
+        logger.info(f"Travel subagent (async) processing: {query[:100]}...")
+
+        travel_client = get_travel_tools_client()
+
+        agent = Agent(
+            name="travel_agent",
+            model=bedrock_model,
+            tools=[travel_client],
+            system_prompt=TRAVEL_AGENT_PROMPT.format(
+                today_date=datetime.now().strftime("%B %d, %Y")
+            ),
+            trace_attributes={
+                "user.id": user_id,
+                "session.id": session_id,
+                "agent.type": "travel_subagent",
+            },
+        )
+
+        result = ""
+        async for event in agent.stream_async(query):
+            if "data" in event:
+                yield {"data": event["data"]}
+            if "current_tool_use" in event:
+                yield {"current_tool_use": event["current_tool_use"]}
+            if "result" in event:
+                result = str(event["result"])
+
+        yield {"result": result}
+
+    except Exception as e:
+        logger.error(f"Travel subagent async error: {e}", exc_info=True)
+        yield {"error": str(e)}


### PR DESCRIPTION
## Summary

Adds the Python application code for the Datadog-instrumented travel concierge agent sample.

### Supervisor Agent
- `agent.py`: Main supervisor with Strands Agents SDK, AgentCore Memory, and streaming support
- `travel_subagent.py`: Travel planning subagent with tool delegation
- `gateway_client.py`: MCP Gateway client for tool server communication
- `dd_init.py`: Pure OTEL TracerProvider with **BatchSpanProcessor** exporting to Datadog LLM Observability (no ddtrace dependency)
- `dynamodb_manager.py`: User profile lookups with scan fallback warning

### MCP Travel Tools Server
- SerpAPI-based search, hotel, and flight tools via FastMCP
- Cleaned tool implementations (removed unused Tavily, Amadeus, weather code)
- Trimmed `requirements.txt` (removed `tavily-python`, `rapidfuzz`)

### MCP Itinerary Tools Server
- DynamoDB-backed itinerary CRUD operations via FastMCP
- Trimmed `requirements.txt` (removed unused `fastapi`, `uvicorn`)

### Key fixes included
- `SimpleSpanProcessor` → `BatchSpanProcessor` in all 3 `dd_init.py` files
- Added `atexit` shutdown handler for proper span flushing
- CORS origins fixed to `https://localhost:9000` (matches actual vite dev server)
- Removed all dead/commented-out code from `server.py`
- Cleaned unused dependencies across all `requirements.txt` files
- Added `Limit=1` + warning log to DynamoDB scan fallback

**PR 1 of 4** — merge this first